### PR TITLE
Add .env.local example and update setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 .env
 .env.*
 !.env.example
+!.env.local.example
 
 # OS/Editor
 .DS_Store

--- a/personal-finance-mvp/.env.local.example
+++ b/personal-finance-mvp/.env.local.example
@@ -1,0 +1,8 @@
+# For local dev with SQLite (recommended to move fast)
+DATABASE_URL="file:./dev.db"
+
+# Demo mode bypasses auth and treats a single demo user as logged in
+DEMO="true"
+
+# For Postgres in prod (comment out SQLite):
+# DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB?schema=public"

--- a/personal-finance-mvp/README.md
+++ b/personal-finance-mvp/README.md
@@ -14,7 +14,7 @@ Production-ish starter you can deploy same-day. Local uses SQLite via Prisma for
 npm install
 
 # 2) Configure env
-cp .env.local.example .env.local
+cp .env.example .env.local  # see .env.local.example for reference
 
 # 3) Create DB & seed demo data
 npm run db:migrate


### PR DESCRIPTION
## Summary
- track `.env.local.example` copied from `.env.example`
- advise copying `.env.example` into `.env.local` in README
- allow committing `.env.local.example` via `.gitignore`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898fd1988348330b582d9f1242a57c4